### PR TITLE
Recursively gather children projects dependencies

### DIFF
--- a/src/main/java/lt/velykis/maven/pdetarget/AddPomDependenciesMojo.java
+++ b/src/main/java/lt/velykis/maven/pdetarget/AddPomDependenciesMojo.java
@@ -192,12 +192,15 @@ public class AddPomDependenciesMojo extends AbstractDependencyFilterMojo {
    * @param p The project to examine
    * @param deps A set where dependencies will be added
    */
-  private void walkDependencies(MavenProject p, Set<Artifact> deps) {
+  @SuppressWarnings("unchecked")
+private void walkDependencies(MavenProject p, Set<Artifact> deps) {
     List<MavenProject> collected = p.getCollectedProjects();
     if (collected != null)
       for (MavenProject sub : collected)
         walkDependencies(sub, deps);
-    deps.addAll(p.getDependencyArtifacts());
+    Set<Artifact> newdeps = p.getDependencyArtifacts();
+    if (newdeps != null)
+    	deps.addAll(p.getDependencyArtifacts());
   }
 
   /**
@@ -219,8 +222,10 @@ public class AddPomDependenciesMojo extends AbstractDependencyFilterMojo {
     Set<String> artifactDirs = new LinkedHashSet<String>();
     for (Artifact artifact : artifacts) {
       File artifactFile = artifact.getFile();
-      String artifactDir = artifactFile.getParentFile().getCanonicalPath();
-      artifactDirs.add(artifactDir);
+      if (artifactFile != null) {
+        String artifactDir = artifactFile.getParentFile().getCanonicalPath();
+        artifactDirs.add(artifactDir);
+      }
     }
     
     return artifactDirs;

--- a/src/main/java/lt/velykis/maven/pdetarget/AddPomDependenciesMojo.java
+++ b/src/main/java/lt/velykis/maven/pdetarget/AddPomDependenciesMojo.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -33,6 +34,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.artifact.filter.collection.AbstractArtifactsFilter;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
@@ -184,6 +186,19 @@ public class AddPomDependenciesMojo extends AbstractDependencyFilterMojo {
     writeXmlFile(doc, outputXmlFile);
   }
 
+  /**
+   * Recursively gathers project dependencies
+   *
+   * @param p The project to examine
+   * @param deps A set where dependencies will be added
+   */
+  private void walkDependencies(MavenProject p, Set<Artifact> deps) {
+    List<MavenProject> collected = p.getCollectedProjects();
+    if (collected != null)
+      for (MavenProject sub : collected)
+        walkDependencies(sub, deps);
+    deps.addAll(p.getDependencyArtifacts());
+  }
 
   /**
    * Resolves Maven project dependencies.
@@ -192,7 +207,9 @@ public class AddPomDependenciesMojo extends AbstractDependencyFilterMojo {
    * @throws MojoExecutionException 
    */
   private Collection<Artifact> resolveDependencies() throws MojoExecutionException {
-    return getResolvedDependencies(true);
+    HashSet<Artifact> deps = new HashSet<Artifact>();
+    walkDependencies(project, deps);
+    return deps;
   }
 
 


### PR DESCRIPTION
This way you can run the plugin on the parent pom, generating a target that includes the dependencies of all the children projects.

I'm quite new to Maven, but I have to work on a maven-based project with a lot of children projects, each with lots of dependencies: the other guys are using Netbeans while I want to use Eclipse, so I made this patch.
